### PR TITLE
修改跳过策略中获取操作命令字符串为空指针的BUG

### DIFF
--- a/modules/foxbpm-engine/src/main/java/org/foxbpm/engine/impl/ProcessEngineConfigurationImpl.java
+++ b/modules/foxbpm-engine/src/main/java/org/foxbpm/engine/impl/ProcessEngineConfigurationImpl.java
@@ -428,7 +428,7 @@ public class ProcessEngineConfigurationImpl extends ProcessEngineConfiguration {
 		taskCommandDefinitionMap = new HashMap<String, TaskCommandDefinition>();
 		commandFilterMap = new HashMap<String, AbstractCommandFilter>();
 		for (TaskCommandDefinition taskCommandDef : getAllTaskCommandDefinitions()) {
-			if(!"system".equals(taskCommandDef.getType())){
+			if(taskCommandDef.getType() != null && !taskCommandDef.getType().equals("")){
 				TaskCommandDefinition tmp = taskCommandDefinitionMap.get(taskCommandDef.getId());
 				if (tmp == null) {
 					taskCommandDefinitions.add(taskCommandDef);


### PR DESCRIPTION
修改改跳过策略中获取操作命令字符串为空指针的BUG,主要是在解析过程中，将system命令过滤掉了